### PR TITLE
Using a file manager API in a cleanup phase

### DIFF
--- a/Sources/Badgy/Helpers/Factory.swift
+++ b/Sources/Badgy/Helpers/Factory.swift
@@ -101,12 +101,15 @@ struct Factory {
     
     func cleanUp(folder: Path) throws {
         do {
-            let folderBase = folder.absolute().description
+            let icons = [
+                folder + Path("top.png"),
+                folder + Path("bottom.png"),
+                folder + Path("badge.png")
+            ]
             
-            try Task.run("rm", "-rf",
-                         "\(folderBase)/top.png",
-                         "\(folderBase)/bottom.png",
-                         "\(folderBase)/badge.png")
+            for icon in icons {
+                try icon.delete()
+            }
         } catch {
             throw CLI.Error(message: "Failed to clean up temporary files")
         }


### PR DESCRIPTION
The PR evicts `rm` from the code base.

Why it's important? Well, the devastation capabilities of `rm` are long well know:
- [nasty-steam-for-linux-bug-can-wipe-all-your-user-files](https://www.extremetech.com/extreme/197686-nasty-steam-for-linux-bug-can-wipe-all-your-user-files)
- [Man accidentally 'deletes his entire company' with one line of bad code](https://news.ycombinator.com/item?id=11496947)
- [What are some crazy "rm -rf" stories you have heard about?](https://www.quora.com/What-are-some-crazy-rm-rf-stories-you-have-heard-about)

Though, safety benefits kinda outweigh the rest. There are additional pros like unify the phase by avoiding spawn of task processes. 
