### PR TITLE
Specify default values for color arguments

### DIFF
--- a/Sources/Badgy/Commands/Badgy.swift
+++ b/Sources/Badgy/Commands/Badgy.swift
@@ -28,16 +28,17 @@ extension Badgy {
             or
         Provide a named color: 'snow' | 'snow1' | ...
         Complete list of named colors: https://imagemagick.org/script/color.php#color_names
+        (default: randomly selected from \(Factory.colors.joined(separator: " | "))
         """)
         var color: ColorCode?
         
-        @Option(help: """
+        @Option(default: "white", help: """
         Specify a valid hex color code in a case insensitive format: '#rrggbb' | '#rrggbbaa'
             or
         Provide a named color: 'snow' | 'snow1' | ...
         Complete list of named colors: https://imagemagick.org/script/color.php#color_names
         """)
-        var tintColor: ColorCode?
+        var tintColor: ColorCode
         
         @Flag(help: "Indicates Badgy should replace the input icon")
         var replace: Bool
@@ -133,7 +134,7 @@ private extension IconSignPipeline {
         var pipeline = IconSignPipeline(icon: options.icon, label: options.label)
         
         pipeline.color = options.color?.value
-        pipeline.tintColor = options.tintColor?.value
+        pipeline.tintColor = options.tintColor.value
         pipeline.replace = options.replace
         
         return pipeline

--- a/Sources/Badgy/Commands/Badgy.swift
+++ b/Sources/Badgy/Commands/Badgy.swift
@@ -28,7 +28,7 @@ extension Badgy {
             or
         Provide a named color: 'snow' | 'snow1' | ...
         Complete list of named colors: https://imagemagick.org/script/color.php#color_names
-        (default: randomly selected from \(Factory.colors.joined(separator: " | "))
+        (default: randomly selected from \(Factory.colors.joined(separator: " | ")))
         """)
         var color: ColorCode?
         

--- a/Sources/Badgy/Helpers/ColorCode.swift
+++ b/Sources/Badgy/Helpers/ColorCode.swift
@@ -22,3 +22,14 @@ extension ColorCode: ExpressibleByArgument {
     }
 }
 
+extension ColorCode: CustomStringConvertible {
+    var description: String {
+        return value
+    }
+}
+
+extension ColorCode: ExpressibleByStringLiteral {
+    init(stringLiteral value: StringLiteralType) {
+        self.init(argument: value)!
+    }
+}

--- a/Sources/Badgy/Helpers/Factory+Small.swift
+++ b/Sources/Badgy/Helpers/Factory+Small.swift
@@ -14,7 +14,7 @@ extension Factory {
                     tintColorHexCode: String? = nil,
                     inFolder folder: Path) throws -> String {
         
-        let color = colorHexCode ?? colors.randomElement()!
+        let color = colorHexCode ?? Factory.colors.randomElement()!
         let tintColor = tintColorHexCode ?? "white"
         
         do {

--- a/Sources/Badgy/Helpers/Factory.swift
+++ b/Sources/Badgy/Helpers/Factory.swift
@@ -11,7 +11,7 @@ import PathKit
 typealias BadgeProductionResponse = ((Result<String, Error>) throws -> Void)
 
 struct Factory {
-    let colors = ["#EE6D6D", "#A36DEE", "#4C967E", "#3B8A4B", "#CABA0E", "#E68C31", "#E11818"]
+    static let colors = ["#EE6D6D", "#A36DEE", "#4C967E", "#3B8A4B", "#CABA0E", "#E68C31", "#E11818"]
     
     func makeBadge(with label: String,
                    colorHexCode: String? = nil,
@@ -20,7 +20,7 @@ struct Factory {
                    inFolder folder: Path) throws -> String {
         
         do {
-            let color = colorHexCode ?? colors.randomElement()!
+            let color = colorHexCode ?? Factory.colors.randomElement()!
             let tintColor = tintColorHexCode ?? "white"
             
             let folderBase = folder.absolute().description


### PR DESCRIPTION
Follow up to the `ArgumentParser` migration and a related conversation https://github.com/arthurpalves/badgy/pull/14#discussion_r443251782

The change leverages `ArgumentParser`'s default values to generate a more insightful help message

Without default values:
```bash
  --color <color>         Specify a valid hex color code in a case insensitive format: '#rrggbb' | '#rrggbbaa'
                              or
                          Provide a named color: 'snow' | 'snow1' | ...
                          Complete list of named colors: https://imagemagick.org/script/color.php#color_names
  --tint-color <tint-color>
                          Specify a valid hex color code in a case insensitive format: '#rrggbb' | '#rrggbbaa'
                              or
                          Provide a named color: 'snow' | 'snow1' | ...
                          Complete list of named colors: https://imagemagick.org/script/color.php#color_names
```

With default values:
```bash
  --color <color>         Specify a valid hex color code in a case insensitive format: '#rrggbb' | '#rrggbbaa'
                              or
                          Provide a named color: 'snow' | 'snow1' | ...
                          Complete list of named colors: https://imagemagick.org/script/color.php#color_names
                          (default: randomly selected from #EE6D6D | #A36DEE | #4C967E | #3B8A4B | #CABA0E | #E68C31 | #E11818)
  --tint-color <tint-color>
                          Specify a valid hex color code in a case insensitive format: '#rrggbb' | '#rrggbbaa'
                              or
                          Provide a named color: 'snow' | 'snow1' | ...
                          Complete list of named colors: https://imagemagick.org/script/color.php#color_names (default: white)
```

Note the `(default:` value specification at the end of each help entry